### PR TITLE
move model org images into main text flow

### DIFF
--- a/model_org_intro.Rmd
+++ b/model_org_intro.Rmd
@@ -67,10 +67,10 @@ Generally the more complex and more similar an organism is to a human, the more 
 
 #### Mouse {-}
 
-<figure style="width: 30%; float: right;">
-![Ilmari Karonen (2006) Common house mouse (*Mus musculus*), wild type. https://commons.wikimedia.org/wiki/File:Mouse_white_background.jpg Public Domain](assets/model_org_intro/mouse.jpg){width=100%}
+```{r, echo=FALSE, fig.alt="Photo of a mouse", fig.cap = "Ilmari Karonen (2006) Common house mouse (*Mus musculus*), wild type. https://commons.wikimedia.org/wiki/File:Mouse_white_background.jpg License: Public Domain"}
 
-</figure>
+knitr::include_graphics("assets/model_org_intro/mouse.jpg")
+```
 
 ##### Genome {-}
 - ~3 billion bases in length (similar to human)
@@ -86,10 +86,10 @@ Generally the more complex and more similar an organism is to a human, the more 
 
 #### Fruit fly {-}
 
-<figure style="width: 30%; float: right;">
-![Sanjay Acharya (2017) A fruit fly (*Drosophila melanogaster*) feeding off a banana. https://commons.wikimedia.org/wiki/File:Drosophila_melanogaster_Proboscis.jpg License: [CC BY 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.en)](assets/model_org_intro/fruit_fly.jpg){width=100%}
+```{r, echo=FALSE, fig.alt="Photo of a fruit fly", fig.cap = "Sanjay Acharya (2017) A fruit fly (*Drosophila melanogaster*) feeding off a banana. https://commons.wikimedia.org/wiki/File:Drosophila_melanogaster_Proboscis.jpg License: [CC BY 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.en)"}
 
-</figure>
+knitr::include_graphics("assets/model_org_intro/fruit_fly.jpg")
+```
 
 ##### Genome {-}
 - ~140 million bases in length
@@ -105,10 +105,10 @@ Generally the more complex and more similar an organism is to a human, the more 
 
 #### Yeast {-}
 
-<figure style="width: 30%; float: right;">
-![Rainis Venta (2011) Drop-inoculation of laboratory baker´s yeast (*Saccharomyces cerevisiae*) mutants on agar plate. https://en.wikipedia.org/wiki/Saccharomyces_cerevisiae#/media/File:Laboratoorne_pagarip%C3%A4rm_(Saccharomyces_cerevisiae)_agariplaadil..JPG License: [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)](assets/model_org_intro/yeast.jpeg){width=100%}
+```{r, echo=FALSE, fig.alt="Photo of yeast growing in a petri dish", fig.cap = "Rainis Venta (2011) Drop-inoculation of laboratory baker´s yeast (*Saccharomyces cerevisiae*) mutants on agar plate. https://en.wikipedia.org/wiki/Saccharomyces_cerevisiae#/media/File:Laboratoorne_pagarip%C3%A4rm_(Saccharomyces_cerevisiae)_agariplaadil..JPG License: [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)"}
 
-</figure>
+knitr::include_graphics("assets/model_org_intro/yeast.jpeg")
+```
 
 ##### Genome {-}
 - ~12 million bases in length
@@ -124,10 +124,10 @@ Generally the more complex and more similar an organism is to a human, the more 
 
 #### *E. coli* {-}
 
-<figure style="width: 30%; float: right;">
-![Madprime (2007) K12 *E. coli* colonies on a plate. https://commons.wikimedia.org/wiki/File:Ecoli_colonies.png License: [CC0 1.0 Universal Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/deed.en)](assets/model_org_intro/ecoli.png){width=100%}
+```{r, echo=FALSE, fig.alt="Photo of E. coli growing in a petri dish", fig.cap = "Madprime (2007) K12 *E. coli* colonies on a plate. https://commons.wikimedia.org/wiki/File:Ecoli_colonies.png License: [CC0 1.0 Universal Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/deed.en)"}
 
-</figure>
+knitr::include_graphics("assets/model_org_intro/ecoli.png")
+```
 
 ##### Genome {-}
 - ~5 million bases in length

--- a/model_org_intro.Rmd
+++ b/model_org_intro.Rmd
@@ -67,7 +67,7 @@ Generally the more complex and more similar an organism is to a human, the more 
 
 #### Mouse {-}
 
-```{r, echo=FALSE, fig.alt="Photo of a mouse", fig.cap = "Ilmari Karonen (2006) Common house mouse (*Mus musculus*), wild type. https://commons.wikimedia.org/wiki/File:Mouse_white_background.jpg License: Public Domain"}
+```{r, echo=FALSE, out.width='40%', fig.alt="Photo of a mouse", fig.cap = "Ilmari Karonen (2006) Common house mouse (*Mus musculus*), wild type. https://commons.wikimedia.org/wiki/File:Mouse_white_background.jpg License: Public Domain"}
 
 knitr::include_graphics("assets/model_org_intro/mouse.jpg")
 ```
@@ -86,7 +86,7 @@ knitr::include_graphics("assets/model_org_intro/mouse.jpg")
 
 #### Fruit fly {-}
 
-```{r, echo=FALSE, fig.alt="Photo of a fruit fly", fig.cap = "Sanjay Acharya (2017) A fruit fly (*Drosophila melanogaster*) feeding off a banana. https://commons.wikimedia.org/wiki/File:Drosophila_melanogaster_Proboscis.jpg License: [CC BY 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.en)"}
+```{r, echo=FALSE, out.width='40%', fig.alt="Photo of a fruit fly", fig.cap = "Sanjay Acharya (2017) A fruit fly (*Drosophila melanogaster*) feeding off a banana. https://commons.wikimedia.org/wiki/File:Drosophila_melanogaster_Proboscis.jpg License: [CC BY 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.en)"}
 
 knitr::include_graphics("assets/model_org_intro/fruit_fly.jpg")
 ```
@@ -105,7 +105,7 @@ knitr::include_graphics("assets/model_org_intro/fruit_fly.jpg")
 
 #### Yeast {-}
 
-```{r, echo=FALSE, fig.alt="Photo of yeast growing in a petri dish", fig.cap = "Rainis Venta (2011) Drop-inoculation of laboratory baker´s yeast (*Saccharomyces cerevisiae*) mutants on agar plate. https://en.wikipedia.org/wiki/Saccharomyces_cerevisiae#/media/File:Laboratoorne_pagarip%C3%A4rm_(Saccharomyces_cerevisiae)_agariplaadil..JPG License: [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)"}
+```{r, echo=FALSE, out.width='40%', fig.alt="Photo of yeast growing in a petri dish", fig.cap = "Rainis Venta (2011) Drop-inoculation of laboratory baker´s yeast (*Saccharomyces cerevisiae*) mutants on agar plate. https://en.wikipedia.org/wiki/Saccharomyces_cerevisiae#/media/File:Laboratoorne_pagarip%C3%A4rm_(Saccharomyces_cerevisiae)_agariplaadil..JPG License: [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)"}
 
 knitr::include_graphics("assets/model_org_intro/yeast.jpeg")
 ```
@@ -124,7 +124,7 @@ knitr::include_graphics("assets/model_org_intro/yeast.jpeg")
 
 #### *E. coli* {-}
 
-```{r, echo=FALSE, fig.alt="Photo of E. coli growing in a petri dish", fig.cap = "Madprime (2007) K12 *E. coli* colonies on a plate. https://commons.wikimedia.org/wiki/File:Ecoli_colonies.png License: [CC0 1.0 Universal Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/deed.en)"}
+```{r, echo=FALSE, out.width='40%', fig.alt="Photo of E. coli growing in a petri dish", fig.cap = "Madprime (2007) K12 *E. coli* colonies on a plate. https://commons.wikimedia.org/wiki/File:Ecoli_colonies.png License: [CC0 1.0 Universal Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/deed.en)"}
 
 knitr::include_graphics("assets/model_org_intro/ecoli.png")
 ```


### PR DESCRIPTION
The side positioning we had in learnr isn't working well in OTTR.  This PR instead inserts them as we do all other images, so the text doesn't get squashed.